### PR TITLE
AGFASLA-66: Configure complex transformer to image for thumbnails

### DIFF
--- a/src/main/amp/config/alfresco/module/com.arondor.arender.alfresco.content.transformer/alfresco-global.properties
+++ b/src/main/amp/config/alfresco/module/com.arondor.arender.alfresco.content.transformer/alfresco-global.properties
@@ -171,3 +171,7 @@ content.transformer.arender2pdf.extensions.xltx.pdf.priority=30
 
 content.transformer.arender2pdf.extensions.zip.pdf.supported=true
 content.transformer.arender2pdf.extensions.zip.pdf.priority=30
+
+# All -> PDF -> Image
+content.transformer.complex.arender2pdf.Image.pipeline=arender2pdf|pdf|complex.PDF.Image
+content.transformer.complex.arender2pdf.Image.priority=200


### PR DESCRIPTION
There's currently no transformer configured for complex transformations from pdf's created via ARender to images necessary for thumbnails. This causes `Unsupported transformation: (...) to application/pdf` errors when no other valid pipelines are available.